### PR TITLE
Add option to disable disk cache, and to specify custom cache path

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SUNRepresentations"
 uuid = "1a50b95c-7aac-476d-a9ce-2bfc675fc617"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Maarten Van Damme <Maarten.VanDamme@UGent.be>, Jutho Haegeman <jutho.haegeman@ugent.be> and Lukas Devos <lukas.devos@UGent.be>"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ CGC disk cache info:
 * SU(3) - Float64 - 32 entries - 134.462 KiB
 ```
 
-The values are stored at `SUNRepresentations.cgc_cache_dir()`, which is a package-wide
+The values are stored at `SUNRepresentations.cgc_cache_dir()`, which by default is a package-wide
 scratchspace. Each file `CGC/N/T/s1/s2.jld2` contains coefficients with datatype `T` for
 the fusion of the `SU(N)` irreps `s1 ⊗ s2 → s3`, where `s3` runs over all possible fusion
 channels. The folder structure is as follows:
@@ -60,6 +60,22 @@ CGC/
 ├── 4/
 └── ...
 ```
+
+### Changing the disk cache location
+
+The location of the disk cache can be changed with `SUNRepresentations.cgc_cache_dir`, for
+example to keep it off a slow or quota-limited home directory:
+
+```julia-repl
+julia> SUNRepresentations.cgc_cache_dir("/scratch/cgc")
+
+julia> SUNRepresentations.cgc_cache_dir()
+"/scratch/cgc"
+```
+
+Passing `nothing` restores the default scratchspace, and `persist=true` stores the location
+in the active project's `LocalPreferences.toml`. Note that switching directories neither
+moves nor removes coefficients that were already cached elsewhere.
 
 ### Disabling the disk cache
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ CGC disk cache info:
 * SU(3) - Float64 - 32 entries - 134.462 KiB
 ```
 
-The values are stored at `SUNRepresentations.CGC_CACHE_PATH`, which is a package-wide
+The values are stored at `SUNRepresentations.cgc_cache_dir()`, which is a package-wide
 scratchspace. Each file `CGC/N/T/s1/s2.jld2` contains coefficients with datatype `T` for
 the fusion of the `SU(N)` irreps `s1 ⊗ s2 → s3`, where `s3` runs over all possible fusion
 channels. The folder structure is as follows:
@@ -59,6 +59,34 @@ CGC/
 │      └── ...
 ├── 4/
 └── ...
+```
+
+### Disabling the disk cache
+
+Reading from and writing to the disk cache is synchronized between processes using file
+locks. On shared filesystems such lock files are often unreliable or slow, which can stall
+computations. The disk cache can therefore be disabled entirely, in which case coefficients
+are only cached in memory for the duration of the session and the scratchspace is never
+created:
+
+```julia-repl
+julia> SUNRepresentations.use_disk_cache(false)
+true
+
+julia> SUNRepresentations.cache_info()
+CGC RAM cache info:
+CacheInfo(; hits=0, misses=0, currentsize=0, maxsize=100000)
+
+CGC disk cache is disabled.
+```
+
+Passing `persist=true` additionally stores the setting in the active project's
+`LocalPreferences.toml`. Since concurrent writes to that file are not safe, the setting can
+also be controlled through the `SUNREPRESENTATIONS_USE_DISK_CACHE` environment variable,
+which is read when the package is loaded and takes precedence over the stored preference:
+
+```bash
+export SUNREPRESENTATIONS_USE_DISK_CACHE=false
 ```
 
 ## Conventions

--- a/src/SUNRepresentations.jl
+++ b/src/SUNRepresentations.jl
@@ -23,6 +23,7 @@ include("naming.jl")
 
 function __init__()
     _init_use_disk_cache!()
+    _init_cgc_cache_dir!()
     return nothing
 end
 

--- a/src/SUNRepresentations.jl
+++ b/src/SUNRepresentations.jl
@@ -21,4 +21,9 @@ include("clebschgordan.jl")
 include("sector.jl")
 include("naming.jl")
 
+function __init__()
+    _init_use_disk_cache!()
+    return nothing
+end
+
 end

--- a/src/caching.jl
+++ b/src/caching.jl
@@ -30,6 +30,8 @@ is also stored in the active project's `LocalPreferences.toml`. Note that writin
 preferences is not safe to do concurrently; on a cluster, prefer the
 `SUNREPRESENTATIONS_USE_DISK_CACHE` environment variable, which is read when the package is
 loaded and takes precedence over the stored preference.
+
+See also [`cgc_cache_dir`](@ref).
 """
 use_disk_cache() = _USE_DISK_CACHE[]
 function use_disk_cache(flag::Bool; persist::Bool = false)
@@ -57,17 +59,51 @@ end
 # Disk cache
 # ----------
 
+# an empty string means the default package-wide scratchspace
 const _CGC_CACHE_DIR = Ref{String}("")
 
 """
     cgc_cache_dir() -> String
+    cgc_cache_dir(path::Union{AbstractString,Nothing}; persist=false) -> Union{String,Nothing}
 
-Path of the package-wide scratchspace that holds the CGC disk cache, creating it if it does
-not exist yet.
+Query or set the directory that holds the CGC disk cache. By default this is a package-wide
+scratchspace, which is created upon first use. Passing a `path` makes the cache live there
+instead, while passing `nothing` restores the default. Setting the directory returns the
+previous setting, again as a `path` or as `nothing` for the default, so that it can be
+restored by feeding it back in.
+
+The directory is not created until something is actually written to it, and switching
+directories neither moves nor removes any coefficients that were already cached elsewhere.
+
+The setting is only changed for the current session, unless `persist=true`, in which case it
+is also stored in the active project's `LocalPreferences.toml`. Note that writing
+preferences is not safe to do concurrently.
+
+See also [`use_disk_cache`](@ref).
 """
 function cgc_cache_dir()
-    isempty(_CGC_CACHE_DIR[]) && (_CGC_CACHE_DIR[] = @get_scratch!("CGC"))
-    return _CGC_CACHE_DIR[]
+    dir = _CGC_CACHE_DIR[]
+    return isempty(dir) ? @get_scratch!("CGC") : dir
+end
+function cgc_cache_dir(path::Union{AbstractString, Nothing}; persist::Bool = false)
+    if path isa AbstractString && isempty(path)
+        throw(ArgumentError("Empty CGC cache directory, use `nothing` to restore the default."))
+    end
+    old = _CGC_CACHE_DIR[]
+    _CGC_CACHE_DIR[] = isnothing(path) ? "" : abspath(expanduser(path))
+    if persist
+        if isnothing(path)
+            @delete_preferences!("cgc_cache_dir")
+        else
+            @set_preferences!("cgc_cache_dir" => _CGC_CACHE_DIR[])
+        end
+    end
+    return isempty(old) ? nothing : old
+end
+
+function _init_cgc_cache_dir!()
+    _CGC_CACHE_DIR[] = @load_preference("cgc_cache_dir", "")
+    return nothing
 end
 
 function cgc_cachepath(s1::SUNIrrep{N}, s2::SUNIrrep{N}, T = Float64) where {N}
@@ -183,9 +219,17 @@ function clear_disk_cache!(N)
     return nothing
 end
 function clear_disk_cache!()
-    Scratch.clear_scratchspaces!(SUNRepresentations)
-    # the scratchspace is gone, so make sure it is recreated on next use
-    _CGC_CACHE_DIR[] = ""
+    if isempty(_CGC_CACHE_DIR[])
+        Scratch.clear_scratchspaces!(SUNRepresentations)
+    else
+        # a custom directory may hold unrelated data, so only remove the SU(N) subtrees
+        dir = _CGC_CACHE_DIR[]
+        isdir(dir) || return nothing
+        for entry in readdir(dir; join = true)
+            isdir(entry) && !isnothing(tryparse(Int, basename(entry))) &&
+                rm(entry; recursive = true)
+        end
+    end
     return nothing
 end
 

--- a/src/caching.jl
+++ b/src/caching.jl
@@ -8,12 +8,74 @@ const CGC_CACHE = LRU{Any, SparseArray{Float64, 4}}(; maxsize = 100_000)
 # convert sector to string key
 _key(s::SUNIrrep) = string(weight(s))
 
-const CGC_CACHE_PATH = @get_scratch!("CGC")
+# Disk cache switch
+# -----------------
+
+const _USE_DISK_CACHE = Ref{Bool}(true)
+
+"""
+    use_disk_cache() -> Bool
+    use_disk_cache(flag::Bool; persist=false) -> Bool
+
+Query or set whether Clebsch-Gordan coefficients are cached on disk. Setting the flag
+returns the previous value.
+
+When the disk cache is disabled, CGCs are never read from or written to disk and the
+scratchspace is never created, so no file locks are taken. The in-memory [`CGC_CACHE`](@ref)
+is unaffected, meaning coefficients are still reused within a session but have to be
+recomputed in the next one.
+
+The setting is only changed for the current session, unless `persist=true`, in which case it
+is also stored in the active project's `LocalPreferences.toml`. Note that writing
+preferences is not safe to do concurrently; on a cluster, prefer the
+`SUNREPRESENTATIONS_USE_DISK_CACHE` environment variable, which is read when the package is
+loaded and takes precedence over the stored preference.
+"""
+use_disk_cache() = _USE_DISK_CACHE[]
+function use_disk_cache(flag::Bool; persist::Bool = false)
+    old = _USE_DISK_CACHE[]
+    _USE_DISK_CACHE[] = flag
+    persist && @set_preferences!("use_disk_cache" => flag)
+    return old
+end
+
+function _init_use_disk_cache!()
+    val = get(ENV, "SUNREPRESENTATIONS_USE_DISK_CACHE", nothing)
+    if !isnothing(val)
+        flag = tryparse(Bool, lowercase(strip(val)))
+        if isnothing(flag)
+            @warn "Ignoring SUNREPRESENTATIONS_USE_DISK_CACHE=$(repr(val)), expected \"true\" or \"false\"."
+        else
+            _USE_DISK_CACHE[] = flag
+            return nothing
+        end
+    end
+    _USE_DISK_CACHE[] = @load_preference("use_disk_cache", true)
+    return nothing
+end
+
+# Disk cache
+# ----------
+
+const _CGC_CACHE_DIR = Ref{String}("")
+
+"""
+    cgc_cache_dir() -> String
+
+Path of the package-wide scratchspace that holds the CGC disk cache, creating it if it does
+not exist yet.
+"""
+function cgc_cache_dir()
+    isempty(_CGC_CACHE_DIR[]) && (_CGC_CACHE_DIR[] = @get_scratch!("CGC"))
+    return _CGC_CACHE_DIR[]
+end
+
 function cgc_cachepath(s1::SUNIrrep{N}, s2::SUNIrrep{N}, T = Float64) where {N}
-    return joinpath(CGC_CACHE_PATH, string(N), string(T), _key(s1), _key(s2))
+    return joinpath(cgc_cache_dir(), string(N), string(T), _key(s1), _key(s2))
 end
 
 function tryread(::Type{T}, s1::SUNIrrep{N}, s2::SUNIrrep{N}, s3::SUNIrrep{N}) where {T, N}
+    use_disk_cache() || return nothing
     fn = cgc_cachepath(s1, s2, T)
     isfile(fn * ".jld2") || return nothing
 
@@ -54,6 +116,8 @@ function generate_CGC(
     ) where {T, N}
     @debug "Generating CGCs: $s1 ⊗ $s2"
     CGCs = _CGC(T, s1, s2, s3)
+    use_disk_cache() || return CGCs
+
     fn = cgc_cachepath(s1, s2, T)
     isdir(dirname(fn)) || mkpath(dirname(fn))
 
@@ -76,6 +140,12 @@ Populate the CGC cache for ``SU(N)`` with eltype `T` with all CGCs with Dynkin l
 Will not recompute CGCs that are already in the cache, unless ``force=true``.
 """
 function precompute_disk_cache(N, a_max::Int = 1, T::Type{<:Number} = Float64; force = false)
+    use_disk_cache() || throw(
+        InvalidStateException(
+            "The CGC disk cache is disabled, enable it with `SUNRepresentations.use_disk_cache(true)`.",
+            :disk_cache_disabled
+        )
+    )
     all_irreps = all_dynkin(SUNIrrep{N}, a_max)
     @sync for s1 in all_irreps, s2 in all_irreps
         if force || !isfile(cgc_cachepath(s1, s2, T) * ".jld2")
@@ -97,7 +167,7 @@ Remove the CGC cache for ``SU(N)`` with eltype `T` from disk. If the arguments a
 specified, this removes the cached CGCs for all values of that parameter.
 """
 function clear_disk_cache!(N, T)
-    fldrname = joinpath(CGC_CACHE_PATH, string(N), string(T))
+    fldrname = joinpath(cgc_cache_dir(), string(N), string(T))
     if isdir(fldrname)
         @info "Removing disk cache SU($N): $T"
         rm(fldrname; recursive = true)
@@ -105,7 +175,7 @@ function clear_disk_cache!(N, T)
     return nothing
 end
 function clear_disk_cache!(N)
-    fldrname = joinpath(CGC_CACHE_PATH, string(N))
+    fldrname = joinpath(cgc_cache_dir(), string(N))
     if isdir(fldrname)
         @info "Removing disk cache SU($N)"
         rm(fldrname; recursive = true)
@@ -114,17 +184,19 @@ function clear_disk_cache!(N)
 end
 function clear_disk_cache!()
     Scratch.clear_scratchspaces!(SUNRepresentations)
+    # the scratchspace is gone, so make sure it is recreated on next use
+    _CGC_CACHE_DIR[] = ""
     return nothing
 end
 
+"""
+    ram_cache_info([io=stdout])
+
+Print information about the in-memory CGC cache to `io`.
+"""
 function ram_cache_info(io::IO = stdout)
-    if isempty(CGC_CACHE)
-        println(io, "CGC RAM cache is empty.")
-    else
-        info = LRUCache.cache_info(CGC_CACHE)
-        println(io, "CGC RAM cache info:")
-        println(io, info)
-    end
+    println(io, "CGC RAM cache info:")
+    println(io, LRUCache.cache_info(CGC_CACHE))
     return nothing
 end
 
@@ -134,14 +206,19 @@ end
 Print information about the CGC disk cache to `io`. If `clean=true`, remove any corrupted files.
 """
 function disk_cache_info(io::IO = stdout; clean = false)
-    if !isdir(CGC_CACHE_PATH) || isempty(readdir(CGC_CACHE_PATH))
-        println("CGC disk cache is empty.")
+    if !use_disk_cache()
+        println(io, "CGC disk cache is disabled.")
+        return nothing
+    end
+    cache_dir = cgc_cache_dir()
+    if !isdir(cache_dir) || isempty(readdir(cache_dir))
+        println(io, "CGC disk cache is empty.")
         return nothing
     end
     println(io, "CGC disk cache info:")
     println(io, "====================")
 
-    for fldr_N in readdir(CGC_CACHE_PATH; join = true)
+    for fldr_N in readdir(cache_dir; join = true)
         isdir(fldr_N) || continue
         N = basename(fldr_N)
         for fldr_T in readdir(fldr_N; join = true)

--- a/test/caching.jl
+++ b/test/caching.jl
@@ -54,6 +54,38 @@ end
     end
 end
 
+@testset "Custom disk cache directory" begin
+    mktempdir() do dir
+        old = SUNRepresentations.cgc_cache_dir(dir)
+        try
+            @test old === nothing  # was using the default scratchspace
+            @test SUNRepresentations.cgc_cache_dir() == abspath(dir)
+            @test_throws ArgumentError SUNRepresentations.cgc_cache_dir("")
+
+            # cache is populated in the custom directory and read back from it
+            @test isempty(readdir(dir))
+            precompute_disk_cache(3, 1)
+            @test !isempty(readdir(dir))
+            @test isdir(joinpath(dir, "3", "Float64"))
+            @test occursin("SU(3)", sprint(SUNRepresentations.disk_cache_info))
+
+            s1 = s2 = SUNIrrep{3}(2, 1, 0)
+            reference = [copy(CGC(Float64, s1, s2, s3)) for s3 in s1 ⊗ s2]
+            empty!(SUNRepresentations.CGC_CACHE)
+            @test all(splat(≈), zip(reference, (CGC(Float64, s1, s2, s3) for s3 in s1 ⊗ s2)))
+
+            # unrelated data in the custom directory is left alone
+            touch(joinpath(dir, "keepme"))
+            clear_disk_cache!()
+            @test readdir(dir) == ["keepme"]
+        finally
+            SUNRepresentations.cgc_cache_dir(old)
+            empty!(SUNRepresentations.CGC_CACHE)
+        end
+        return @test SUNRepresentations.cgc_cache_dir() != abspath(dir)
+    end
+end
+
 @testset "Disk cache environment variable" begin
     old = SUNRepresentations.use_disk_cache()
     try

--- a/test/caching.jl
+++ b/test/caching.jl
@@ -23,3 +23,55 @@ if get(ENV, "CI", false) == "true"
     println("Detected running on CI")
     clear_disk_cache!(3, Float64)
 end
+
+@testset "RAM cache info" begin
+    # https://github.com/QuantumKitHub/SUNRepresentations.jl/issues/43
+    # info should be shown even when the cache is empty
+    empty!(SUNRepresentations.CGC_CACHE)
+    str = sprint(SUNRepresentations.ram_cache_info)
+    @test occursin("currentsize=0", str)
+    @test occursin("maxsize=$(SUNRepresentations.CGC_CACHE.maxsize)", str)
+end
+
+@testset "Optional disk cache" begin
+    old = SUNRepresentations.use_disk_cache()
+    try
+        @test SUNRepresentations.use_disk_cache(false) == old
+        @test !SUNRepresentations.use_disk_cache()
+        @test occursin("disabled", sprint(SUNRepresentations.disk_cache_info))
+        @test_throws InvalidStateException precompute_disk_cache(3, 1)
+
+        # CGCs are unaffected by the disk cache being disabled
+        s1 = s2 = SUNIrrep{3}(2, 1, 0)
+        empty!(SUNRepresentations.CGC_CACHE)
+        without = [copy(CGC(Float64, s1, s2, s3)) for s3 in s1 ⊗ s2]
+        SUNRepresentations.use_disk_cache(true)
+        empty!(SUNRepresentations.CGC_CACHE)
+        with = [CGC(Float64, s1, s2, s3) for s3 in s1 ⊗ s2]
+        @test all(splat(≈), zip(without, with))
+    finally
+        SUNRepresentations.use_disk_cache(old)
+    end
+end
+
+@testset "Disk cache environment variable" begin
+    old = SUNRepresentations.use_disk_cache()
+    try
+        for flag in (false, true)
+            withenv("SUNREPRESENTATIONS_USE_DISK_CACHE" => string(flag)) do
+                SUNRepresentations._init_use_disk_cache!()
+                return @test SUNRepresentations.use_disk_cache() == flag
+            end
+        end
+        # invalid values are ignored, falling back to the preference
+        withenv("SUNREPRESENTATIONS_USE_DISK_CACHE" => "yes") do
+            @test_logs (:warn,) SUNRepresentations._init_use_disk_cache!()
+            return @test SUNRepresentations.use_disk_cache() ==
+                SUNRepresentations.Preferences.load_preference(
+                SUNRepresentations, "use_disk_cache", true
+            )
+        end
+    finally
+        SUNRepresentations.use_disk_cache(old)
+    end
+end


### PR DESCRIPTION
I've been having quite a lot of issues using the SU(3) CGCs in simulations on a shared memory cluster, with spurious crashes (invalid JLD2 files) related to the CGC disk cache. I don't know what's going wrong exactly there, but it seemed useful to me to have the option to disable the disk cache altogether when running restrictive or unfamiliar file systems.

In addition, I think it would be useful to be able to manually set the cache path. I didn't even get to experience this problem, but for my workflow the default scratch space is created in a working partition of the disk with very limited storage space. Since the disk cache can become quite big (as observed running the same simulations on a different machine), this could very quickly flood the whole working disk partition and cripple all of my jobs

This makes disk caching optional, with the default remaining using the disk cache. This can either be set per-session, stored as a local preference, or specified using an environment variable. It also allows to specify a custom cache path in the same way. Not sure about the design so all comments are welcome, but I think

I also snuck in a fix for #43 while I was at it.